### PR TITLE
BTA-5797 Release `1.12.2` version to include missing PayoutMethodDetails country enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,6 @@ Class | Method | HTTP request | Description
 *WebhooksApi* | [**getWebhooks**](docs/WebhooksApi.md#getWebhooks) | **GET** /webhooks | Listing webhooks
 *WebhooksApi* | [**postWebhooks**](docs/WebhooksApi.md#postWebhooks) | **POST** /webhooks | Creating a webhook
 
-
 ## Documentation for Models
 
  - [Account](docs/Account.md)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>com.transferzero.sdk</groupId>
   <artifactId>transferzero-sdk-java7</artifactId>
-  <version>1.12.0-SNAPSHOT</version>
+  <version>1.12.2-SNAPSHOT</version>
   <scope>compile</scope>
 </dependency>
 ```
@@ -55,7 +55,7 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "com.transferzero.sdk:transferzero-sdk-java7:1.12.0-SNAPSHOT"
+compile "com.transferzero.sdk:transferzero-sdk-java7:1.12.2-SNAPSHOT"
 ```
 
 ### Others
@@ -68,7 +68,7 @@ mvn clean package
 
 Then manually install the following JARs:
 
-* `target/transferzero-sdk-java7-1.12.0-SNAPSHOT.jar`
+* `target/transferzero-sdk-java7-1.12.2-SNAPSHOT.jar`
 * `target/lib/*.jar`
 
 ## Getting Started

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'eclipse'
 apply plugin: 'java'
 
 group = 'com.transferzero.sdk'
-version = '1.12.0-SNAPSHOT'
+version = '1.12.2-SNAPSHOT'
 
 buildscript {
     repositories {

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file(".")).
   settings(
     organization := "com.transferzero.sdk",
     name := "transferzero-sdk-java7",
-    version := "1.12.0-SNAPSHOT",
+    version := "1.12.2-SNAPSHOT",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
     javacOptions in compile ++= Seq("-Xlint:deprecation"),

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,11 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.transferzero.sdk</groupId>
     <artifactId>transferzero-sdk-java7</artifactId>
     <packaging>jar</packaging>
     <name>transferzero-sdk-java7</name>
-    <version>1.12.0-SNAPSHOT</version>
+    <version>1.12.2-SNAPSHOT-SNAPSHOT</version>
     <url>https://github.com/transferzero/transferzero-sdk-java7</url>
     <description>Java 7 library for the TransferZero API</description>
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>transferzero-sdk-java7</artifactId>
     <packaging>jar</packaging>
     <name>transferzero-sdk-java7</name>
-    <version>1.12.3-SNAPSHOT</version>
+    <version>1.12.2-SNAPSHOT</version>
     <url>https://github.com/transferzero/transferzero-sdk-java7</url>
     <description>Java 7 library for the TransferZero API</description>
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
     <artifactId>transferzero-sdk-java7</artifactId>
     <packaging>jar</packaging>
     <name>transferzero-sdk-java7</name>
-    <version>1.12.2</version>
+    <version>1.12.3-SNAPSHOT</version>
     <url>https://github.com/transferzero/transferzero-sdk-java7</url>
     <description>Java 7 library for the TransferZero API</description>
     <scm>
         <connection>scm:git:https://github.com/transferzero/transferzero-sdk-java7.git</connection>
         <developerConnection>scm:git:git@github.com:transferzero/transferzero-sdk-java7.git</developerConnection>
         <url>https://github.com/transferzero/transferzero-sdk-java7</url>
-        <tag>transferzero-sdk-java7-1.12.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -1,18 +1,17 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.transferzero.sdk</groupId>
     <artifactId>transferzero-sdk-java7</artifactId>
     <packaging>jar</packaging>
     <name>transferzero-sdk-java7</name>
-    <version>1.12.2-SNAPSHOT-SNAPSHOT</version>
+    <version>1.12.2</version>
     <url>https://github.com/transferzero/transferzero-sdk-java7</url>
     <description>Java 7 library for the TransferZero API</description>
     <scm>
         <connection>scm:git:https://github.com/transferzero/transferzero-sdk-java7.git</connection>
         <developerConnection>scm:git:git@github.com:transferzero/transferzero-sdk-java7.git</developerConnection>
         <url>https://github.com/transferzero/transferzero-sdk-java7</url>
-        <tag>HEAD</tag>
+        <tag>transferzero-sdk-java7-1.12.2</tag>
     </scm>
 
     <licenses>


### PR DESCRIPTION
BTA-5797: Release `1.12.2` version to include missing PayoutMethodDetails country enums