### PR TITLE
AZAMIG-61: Bump SDK version to 1.37.6-SNAPSHOT for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>com.transferzero.sdk</groupId>
   <artifactId>transferzero-sdk-java7</artifactId>
-  <version>1.37.4-SNAPSHOT</version>
+  <version>1.37.6-SNAPSHOT</version>
   <scope>compile</scope>
 </dependency>
 ```
@@ -55,7 +55,7 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "com.transferzero.sdk:transferzero-sdk-java7:1.37.4-SNAPSHOT"
+compile "com.transferzero.sdk:transferzero-sdk-java7:1.37.6-SNAPSHOT"
 ```
 
 ### Others
@@ -68,7 +68,7 @@ mvn clean package
 
 Then manually install the following JARs:
 
-* `target/transferzero-sdk-java7-1.37.4-SNAPSHOT.jar`
+* `target/transferzero-sdk-java7-1.37.6-SNAPSHOT.jar`
 * `target/lib/*.jar`
 
 ## Getting Started

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'eclipse'
 apply plugin: 'java'
 
 group = 'com.transferzero.sdk'
-version = '1.37.4-SNAPSHOT'
+version = '1.37.6-SNAPSHOT'
 
 buildscript {
     repositories {

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file(".")).
   settings(
     organization := "com.transferzero.sdk",
     name := "transferzero-sdk-java7",
-    version := "1.37.4-SNAPSHOT",
+    version := "1.37.6-SNAPSHOT",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
     javacOptions in compile ++= Seq("-Xlint:deprecation"),

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>transferzero-sdk-java7</artifactId>
     <packaging>jar</packaging>
     <name>transferzero-sdk-java7</name>
-    <version>1.37.5-SNAPSHOT</version>
+    <version>1.37.6-SNAPSHOT</version>
     <url>https://github.com/transferzero/transferzero-sdk-java7</url>
     <description>Java 7 library for the TransferZero API</description>
     <scm>


### PR DESCRIPTION
## Summary

One-line version bump to `1.37.6-SNAPSHOT` (pom.xml, README.md, build.gradle, build.sbt) so the next `release.yml` workflow_dispatch can publish 1.37.6 to Maven Central.

## Why this is needed

`1.37.5` is already on Maven Central (published as part of the prior Java-only release cycle — see [bitpesa-api-specification#423](https://github.com/bitpesa/bitpesa-api-specification/pull/423)). Triggering `release.yml` while pom.xml still says `1.37.5-SNAPSHOT` would 400 on Sonatype staging close. Bumping to `1.37.6-SNAPSHOT` lets `maven-release-plugin` default the release version to `1.37.6` and the next dev version to `1.37.7-SNAPSHOT`.

## Release contents

This release ships AZAMIG-61 (ZAR Bidvest mandate-bypass-eligible `transfer_reason` keys):
- 25 curated short-form keys (15 net-new) documented on `PayoutMethodTransferReasonEnum`.
- 15 new enum values now accepted: `own_account`, `donations_gifts`, `family_support`, `mortgage_repayment`, `business_travel`, `personal_travel`, `management_consulting`, `advertising_market_research`, `cultural_recreational`, `salary_resident_abroad`, `salary_non_resident_in_sa`, `salary_foreign_contract_in_sa`, `commission_brokerage`, `investment_income`, `architectural_engineering`.

The regenerated client code already landed on master via CodeBuild after [bitpesa-api-specification#424](https://github.com/bitpesa/bitpesa-api-specification/pull/424).

## Test plan

- [ ] After merge, trigger `release.yml` workflow_dispatch with `tag_name=v1.37.6`.
- [ ] Verify Sonatype staging close succeeds (no 400).
- [ ] `curl -sI https://repo1.maven.org/maven2/com/transferzero/sdk/transferzero-sdk-java8/1.37.6/transferzero-sdk-java8-1.37.6.pom` returns 200.
- [ ] Unzip the published sources jar and confirm `PayoutMethodTransferReasonEnum.java` includes the 15 new enum entries.
