### PR TITLE
Bump SDK version to 1.37.7-SNAPSHOT for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>com.transferzero.sdk</groupId>
   <artifactId>transferzero-sdk-java7</artifactId>
-  <version>1.37.6-SNAPSHOT</version>
+  <version>1.37.7-SNAPSHOT</version>
   <scope>compile</scope>
 </dependency>
 ```
@@ -55,7 +55,7 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "com.transferzero.sdk:transferzero-sdk-java7:1.37.6-SNAPSHOT"
+compile "com.transferzero.sdk:transferzero-sdk-java7:1.37.7-SNAPSHOT"
 ```
 
 ### Others
@@ -68,7 +68,7 @@ mvn clean package
 
 Then manually install the following JARs:
 
-* `target/transferzero-sdk-java7-1.37.6-SNAPSHOT.jar`
+* `target/transferzero-sdk-java7-1.37.7-SNAPSHOT.jar`
 * `target/lib/*.jar`
 
 ## Getting Started

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'eclipse'
 apply plugin: 'java'
 
 group = 'com.transferzero.sdk'
-version = '1.37.6-SNAPSHOT'
+version = '1.37.7-SNAPSHOT'
 
 buildscript {
     repositories {

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file(".")).
   settings(
     organization := "com.transferzero.sdk",
     name := "transferzero-sdk-java7",
-    version := "1.37.6-SNAPSHOT",
+    version := "1.37.7-SNAPSHOT",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
     javacOptions in compile ++= Seq("-Xlint:deprecation"),

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>transferzero-sdk-java7</artifactId>
     <packaging>jar</packaging>
     <name>transferzero-sdk-java7</name>
-    <version>1.37.6-SNAPSHOT</version>
+    <version>1.37.7-SNAPSHOT</version>
     <url>https://github.com/transferzero/transferzero-sdk-java7</url>
     <description>Java 7 library for the TransferZero API</description>
     <scm>


### PR DESCRIPTION
## Summary

Manual `pom.xml` / README / build.gradle / build.sbt bump to `1.37.7-SNAPSHOT` in preparation for the 1.37.7 release that exposes the new `MandatesApi#getMandate` operation (see bitpesa-api-specification PR #427).

`pom.xml` is not regenerated by the spec deploy — openapi-generator-4.0.0-beta3 registers it as a supporting file with `overwrite=false`, so every release cycle needs this one-line bump PR (same pattern as #85, #86, #87).

## Test plan

- [ ] Admin-merge alongside spec PR #427
- [ ] `gh workflow run release.yml --ref master -f tag_name=v1.37.7`
- [ ] `curl -sI https://repo1.maven.org/maven2/com/transferzero/sdk/transferzero-sdk-java7/1.37.7/transferzero-sdk-java7-1.37.7.pom` returns `HTTP/2 200`
